### PR TITLE
Run do_shortcode() on EVENT_META_*

### DIFF
--- a/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
+++ b/core/libraries/shortcodes/EE_Event_Shortcodes.lib.php
@@ -237,7 +237,7 @@ class EE_Event_Shortcodes extends EE_Shortcodes
             // pull the meta value from the event post
             $event_meta = $this->_event->get_post_meta($shortcode, true);
 
-            return ! empty($event_meta) ? $this->_event->get_post_meta($shortcode, true) : '';
+            return ! empty($event_meta) ? do_shortcode($this->_event->get_post_meta($shortcode, true)) : '';
         }
 
         if (strpos($shortcode, '[EVENT_TOTAL_AVAILABLE_SPACES_*') !== false) {


### PR DESCRIPTION
In case there are shortcodes in the post_meta, running do_shortcode() ensures the shortcode output is correctly parsed. Previously, shortcodes in post_meta (such as ACF wysiwyg fields) were ignored.


<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
THis is a very simple patch to fix an issue I discovered while trying to use EVENT_META_* shortcodes to include text that itself has a shortcode in it. 

I maintain HTML text in a custom field using ACF. I use EVENT_META_* shortcode in EMAIL message templates to render this text. Previous to this patch, shortcodes in the post_meta custom field were not being parsed. After this patch, the shortcode is correctly parsed and the post_meta field text is included with the correctly parsed shortcode.

I don't believe this will have any adverse effects because it is just a small change to allow shortcodes to be used in post_meta data.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
I modified the core and generated an email. I looked at the email - it contained no errors and carried the properly parsed shortcode output.

## Checklist

* [X] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [X] User input is adequately validated and sanitized
* [X] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [X] My code is tested.
* [X] My code follows the Event Espresso code style.
* [X] My code has proper inline documentation.
* [X] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
